### PR TITLE
Add hover effect to dropdown menu

### DIFF
--- a/assets/styles/form.css
+++ b/assets/styles/form.css
@@ -6,7 +6,7 @@ button {
     margin: auto;
 
     @media (min-width: 768px) {
-    padding: 0.5rem;
+        padding: 0.5rem;
     }
 }
 
@@ -22,9 +22,17 @@ select {
     border-radius: 5px;
     font-weight: 300;
     padding: 0.5rem 1.5rem;
+    transition: background-color 0.25s ease, 
+                box-shadow 0.25s ease; 
 }
 
 select:focus-visible {
-    border-color: white;
-    border: 1px;
+    outline: none;
+    border: 1px solid var(--color-primary);
+}
+
+select:hover:not(:focus) {
+    background-color: rgba(206, 175, 175, 0.015); 
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05); 
+    cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <h1>Meal Randomizer!</h1>     
         <form class="dropdown">
             <select id ="dropdown-menu">
-                <option valur="default">Please choose a category!</option>
+                <option value="default">Please choose a category!</option>
                 <option id="display-meal-beef" class="dropdown-content">Beef</option>
                 <option id="display-meal-chicken">Chicken</option>
                 <option id="display-meal-dessert">Dessert</option>


### PR DESCRIPTION
What did I change?
Added a subtle hover effect to the dropdown  element by updating styles in assets/styles/form.css.
Applied a smooth transition with a slight background-color change to improve user interaction feedback.

Why did I make this change?
Interactive elements should provide visual feedback when hovered. This small improvement makes the dropdown feel more responsive, professional, and user-friendly.

How did I test it?
-Tested in a web browser to confirm the hover effect appears correctly
-Tried selecting different meal categories to ensure functionality wasn’t affected
-Checked styling on mobile to make sure the hover effect didn’t cause layout issues
-Verified smooth transition across Chrome, Firefox, and Safari

Here is video that shows how this hover effect works
https://github.com/user-attachments/assets/ced5cd92-7bfd-4745-ae9b-7e6988038f51

Feel free to contact me for any changes or improvements